### PR TITLE
Remove install command, use update instead. Some message clean-ups.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,12 @@
 #!/bin/bash
 
-# Colours.
+# Colour definition.
 GREEN="\e[32m"
 BLUE="\e[34m"
 BLACK="\e[30m"
 RESET="\e[0m"
 
-# Ask yes or no.
-# Parameters:
-# 1: Question to ask.
-# 2: Command to run if yes.
-# 3: Command to run if no.
+# Ask yes or no, repeat function if invalid response.
 ask_yes_or_no() {
 	read -p "${1}: " answer
 	answer=$(echo $answer | awk '{print tolower($0)}')
@@ -43,6 +39,8 @@ start() {
 }
 
 collect_information() {
+	# TODO: Make this look a lot cleaner..
+
 	# Ask for a bit of information
 	echo -ne "${BLUE}Game server name:${RESET} "
 	read server_name
@@ -73,6 +71,7 @@ download() {
 }
 
 install() {
+	# TODO: Make this cleaner.	
 	echo -e "${GREEN}Settings"
 	echo -e "${RESET}==============="
 	echo -e "${BLUE}Server Name:${RESET} ${server_name}"

--- a/payload/script.sh
+++ b/payload/script.sh
@@ -7,9 +7,11 @@
 fn_okay() {
     echo -e "\r\033[K[\e[0;32m  OK  \e[0;39m] $@"
 }
+
 fn_fail() {
 	echo -e "\r\033[K[\e[0;31m FAIL \e[0;39m] $@"
 }
+
 ask_yes_or_no() {
 	read -p "${1}: " answer
 	answer=$(echo $answer | awk '{print tolower($0)}')
@@ -75,7 +77,7 @@ command() {
 	fi
 }
 
-console() {
+attach() {
 	tmuxwc=$(tmux list-sessions 2>&1|grep -v failed|grep -E "^${game_name}:"|wc -l)
 	if [ ${tmuxwc} -eq 1 ]; then
 		fn_okay "Attaching to ${game_name}."
@@ -92,7 +94,7 @@ install() {
 }
 
 install_sourcemod() {
-	read -p "Game name (eg. tf, csgo, css): " game_name
+	read -p "Game folder (eg. tf, csgo, css): " game_name
 
 	download_sourcemod
 
@@ -105,7 +107,7 @@ install_sourcemod() {
 	cp addons/ cfg/ ${srcds_location}/${game_name}/ -rf
 	rm addons/ cfg/ -rf
 
-	fn_okay "Successfully installed MetaMod and SourceMod."
+	fn_okay "Successfully installed MetaMod & SourceMod."
 }
 
 download_sourcemod() {
@@ -144,17 +146,14 @@ case $1 in
 	command)
 		command ${*:2}
 		;;
-	console)
-		console
-		;;
-	install)
-		install
+	attach)
+		attach
 		;;
 	update)
 		stop
 		install
 		;;
 	*)
-		echo "Usage: $0 (start|stop|restart|status|command|console|install|update)"
+		echo "Usage: $0 (start|stop|restart|status|command|attach|update"
 		;;
 esac


### PR DESCRIPTION
### Changes
- Removed `install` command.
- Cleaned up some messages throughout script.

### Rationale
- Removed `install` command, since `update` command served the same purpose.